### PR TITLE
chore: use shared renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,23 +1,4 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "config:recommended",
-        ":semanticCommitTypeAll(deps)",
-        ":semanticCommitScopeDisabled"
-    ],
-    "semanticCommits": "enabled",
-    "packageRules": [
-        {
-            "matchUpdateTypes": ["patch"],
-            "automerge": true
-        },
-        {
-            "matchPackageNames": ["oxfmt", "oxlint", "oxlint-tsgolint"],
-            "automerge": true
-        },
-        {
-            "matchUpdateTypes": ["minor", "major"],
-            "reviewers": ["@treetrum"]
-        }
-    ]
+    "extends": ["github>treetrum/renovate-config"]
 }


### PR DESCRIPTION
## Summary
- switch local Renovate config to extend github>treetrum/renovate-config
- centralize Renovate behavior so future changes happen in one shared preset